### PR TITLE
ignore *.base64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ public/
 .cache
 
 TODO
+
+*.base64


### PR DESCRIPTION
- openapi package generates base64 versions of the openapi
  only for convenience when updating AWS CloudFormation canned responses
  should not be version-controlled (gets generated from source)